### PR TITLE
Fix: use macos-latest for x86_64 build

### DIFF
--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -15,7 +15,7 @@ jobs:
             arch: arm64
             suffix: ""
           - target: x86_64-apple-darwin
-            runner: macos-13
+            runner: macos-latest
             arch: x86_64
             suffix: "-x86_64"
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
macos-13 runner is no longer supported. Cross-compile x86_64 from ARM64 macos-latest instead.