### PR TITLE
fix(bash): prefix milliseconds with 10# to prevent octal parsing errors

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -408,7 +408,7 @@ __suvadu_time_ms() {
     if [[ -n "$EPOCHREALTIME" ]]; then
         local secs="${EPOCHREALTIME%%.*}"
         local frac="${EPOCHREALTIME##*.}"
-        echo "$(( secs * 1000 + ${frac:0:3} ))"
+        echo "$(( secs * 1000 + 10#${frac:0:3} ))"
     else
         # Fallback: date +%s gives seconds, multiply by 1000
         echo "$(( $(date +%s) * 1000 ))"


### PR DESCRIPTION
Force base-10 evaluation for the fractional part of `EPOCHREALTIME`. Bash interprets leading zeros as octal, causing "value too great for base" errors when 2- or 3-digit numbers below `100` contain 8 or 9 (e.g., `068`).