### PR TITLE
Updated workflows to enable installation via brew for arm64 and x86 on MacOS and Linux

### DIFF
--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -3,7 +3,7 @@ name: Release Linux
 on:
   push:
     tags:
-      - 'v*'
+      - 'v*' # Triggers on tags like v0.1.0, v1.0.0
 
 jobs:
   build-linux:
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
+      - name: Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust
@@ -38,11 +38,11 @@ jobs:
         if: matrix.use_cross
         run: cargo install cross --version 0.2.5
 
-      - name: Run tests
+      - name: Run Tests
         if: ${{ !matrix.use_cross }}
         run: cargo test
 
-      - name: Build binary
+      - name: Build Binary (Release)
         run: |
           set -euo pipefail
           if [ "${{ matrix.use_cross }}" = "true" ]; then
@@ -60,7 +60,7 @@ jobs:
           sudo cp minisign-linux/x86_64/minisign /usr/local/bin/
           rm -f /tmp/minisign.tar.gz
 
-      - name: Prepare release files
+      - name: Prepare Artifacts
         env:
           MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
         run: |
@@ -81,7 +81,7 @@ jobs:
             -x "out/${{ matrix.archive_name }}.minisig"
           rm -f /tmp/minisign.key
 
-      - name: Upload workflow artifact
+      - name: Upload Workflow Artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: linux-${{ matrix.arch }}
@@ -99,22 +99,22 @@ jobs:
       cancel-in-progress: false
 
     steps:
-      - name: Checkout source repo
+      - name: Checkout Source Repo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Download x86_64 artifact
+      - name: Download x86_64 Artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: linux-x86_64
           path: artifacts/x86_64
 
-      - name: Download aarch64 artifact
+      - name: Download aarch64 Artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: linux-aarch64
           path: artifacts/aarch64
 
-      - name: Prepare combined artifacts tree
+      - name: Prepare Combined Artifacts Tree
         run: |
           set -euo pipefail
 
@@ -146,9 +146,9 @@ jobs:
           r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           r2-bucket: ${{ secrets.R2_BUCKET }}
           source-dir: artifacts
-          destination-dir: ./
+          destination-dir: ./ # Destination prefix in bucket
 
-      - name: Purge Cloudflare CDN cache
+      - name: Purge Cloudflare CDN Cache
         run: |
           curl -s -X POST \
             "https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE_ID }}/purge_cache" \
@@ -166,14 +166,14 @@ jobs:
               ]
             }'
 
-      - name: Checkout Homebrew tap
+      - name: Checkout Homebrew Tap
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: AppachiTech/homebrew-suvadu
           token: ${{ secrets.GH_PAT }}
           path: homebrew-tap
 
-      - name: Update Homebrew tap
+      - name: Update Homebrew Tap
         run: |
           set -euo pipefail
 
@@ -253,7 +253,7 @@ jobs:
             done
           fi
 
-      - name: Create GitHub release
+      - name: Create GitHub Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           generate_release_notes: false

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -92,6 +92,11 @@ jobs:
     name: Publish Linux release
     runs-on: ubuntu-latest
     needs: build-linux
+    # Serialize against the macOS publish job: both update the same Homebrew
+    # formula in AppachiTech/homebrew-suvadu, so they must not push in parallel.
+    concurrency:
+      group: homebrew-tap-update
+      cancel-in-progress: false
 
     steps:
       - name: Checkout source repo
@@ -208,8 +213,25 @@ jobs:
           if git diff --cached --quiet; then
             echo "No Homebrew tap changes to commit."
           else
-            git commit -m "Update suvadu to ${TAG}"
-            git push
+            git commit -m "Update suvadu (linux) to ${TAG}"
+
+            # The concurrency group serializes us against the macOS workflow,
+            # but rebase-and-retry anyway in case the tap moved under us (e.g. a
+            # manual re-run). The linux/macOS edits touch disjoint blocks of the
+            # formula, so a rebase merges cleanly.
+            BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+            for attempt in 1 2 3 4 5; do
+              if git push origin "HEAD:${BRANCH}"; then
+                echo "Pushed tap update on attempt ${attempt}."
+                break
+              fi
+              if [ "${attempt}" -eq 5 ]; then
+                echo "ERROR: failed to push tap update after ${attempt} attempts." >&2
+                exit 1
+              fi
+              echo "Push rejected (attempt ${attempt}); rebasing on origin/${BRANCH}..."
+              git pull --rebase origin "${BRANCH}"
+            done
           fi
 
       - name: Create GitHub release

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           targets: ${{ matrix.target }}
 
@@ -82,7 +82,7 @@ jobs:
           rm -f /tmp/minisign.key
 
       - name: Upload workflow artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: linux-${{ matrix.arch }}
           path: out/*
@@ -100,16 +100,16 @@ jobs:
 
     steps:
       - name: Checkout source repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download x86_64 artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: linux-x86_64
           path: artifacts/x86_64
 
       - name: Download aarch64 artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: linux-aarch64
           path: artifacts/aarch64
@@ -139,7 +139,7 @@ jobs:
           echo "${GITHUB_REF_NAME#v}" > artifacts/version.txt
 
       - name: Upload to Cloudflare R2
-        uses: ryand56/r2-upload-action@b801a390acbdeb034c5e684ff5e1361c06639e7c
+        uses: ryand56/r2-upload-action@b801a390acbdeb034c5e684ff5e1361c06639e7c # v1.4
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -167,7 +167,7 @@ jobs:
             }'
 
       - name: Checkout Homebrew tap
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: AppachiTech/homebrew-suvadu
           token: ${{ secrets.GH_PAT }}
@@ -254,7 +254,7 @@ jobs:
           fi
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           generate_release_notes: false
           files: |

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -205,6 +205,25 @@ jobs:
 
           rm -f "${FORMULA_PATH}.bak"
 
+          # Fail loudly if the sed substitutions did not land — e.g. the formula
+          # layout changed, or homebrew-suvadu#3 (which defines that layout) is
+          # not merged yet. Without this check an unchanged formula would slip
+          # through the "nothing to commit" guard below and users would silently
+          # receive a stale tarball URL / checksum.
+          assert_in_formula() {
+            local label="$1" needle="$2"
+            if ! grep -qF -- "$needle" "$FORMULA_PATH"; then
+              echo "ERROR: ${label} not found in ${FORMULA_PATH} after sed: ${needle}" >&2
+              echo "       Formula layout may have changed or homebrew-suvadu#3 is unmerged;" >&2
+              echo "       refusing to push a stale formula." >&2
+              exit 1
+            fi
+          }
+          assert_in_formula "linux x86_64 url"     "$X64_URL"
+          assert_in_formula "linux x86_64 sha256"  "$X64_SHA"
+          assert_in_formula "linux aarch64 url"    "$ARM_URL"
+          assert_in_formula "linux aarch64 sha256" "$ARM_SHA"
+
           cd homebrew-tap
           git config user.name "Appachi Bot"
           git config user.email "bot@appachi.tech"

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -3,28 +3,34 @@ name: Release Linux
 on:
   push:
     tags:
-      - 'v*' # Triggers on tags like v0.1.0, v1.0.0
+      - 'v*'
 
 jobs:
-  deploy-linux:
+  build-linux:
+    name: Build Linux (${{ matrix.arch }})
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
             arch: x86_64
             suffix: ""
             use_cross: false
+            archive_name: suv-linux-${{ github.ref_name }}.tar.gz
           - target: aarch64-unknown-linux-gnu
             arch: aarch64
             suffix: "-aarch64"
             use_cross: true
+            archive_name: suv-linux-aarch64-${{ github.ref_name }}.tar.gz
+
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
 
@@ -32,12 +38,13 @@ jobs:
         if: matrix.use_cross
         run: cargo install cross --version 0.2.5
 
-      - name: Run Tests
+      - name: Run tests
         if: ${{ !matrix.use_cross }}
         run: cargo test
 
-      - name: Build Binary (Release)
+      - name: Build binary
         run: |
+          set -euo pipefail
           if [ "${{ matrix.use_cross }}" = "true" ]; then
             cross build --release --target ${{ matrix.target }}
           else
@@ -46,53 +53,97 @@ jobs:
 
       - name: Install minisign
         run: |
+          set -euo pipefail
           curl -fsSL -o /tmp/minisign.tar.gz https://github.com/jedisct1/minisign/releases/download/0.11/minisign-0.11-linux.tar.gz
           echo "f0a0954413df8531befed169e447a66da6868d79052ed7e892e50a4291af7ae0  /tmp/minisign.tar.gz" | sha256sum -c -
           tar xzf /tmp/minisign.tar.gz
           sudo cp minisign-linux/x86_64/minisign /usr/local/bin/
           rm -f /tmp/minisign.tar.gz
 
-      - name: Prepare Artifacts
+      - name: Prepare release files
         env:
           MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
         run: |
-          # Create directory structure for R2
-          mkdir -p artifacts/linux/archive
+          set -euo pipefail
 
-          # Prepare binary
+          mkdir -p out
+
           cp target/${{ matrix.target }}/release/suv suv
 
-          # Create main tarball (e.g. suv-linux-latest.tar.gz or suv-linux-aarch64-latest.tar.gz)
-          tar -czf artifacts/linux/suv-linux${{ matrix.suffix }}-latest.tar.gz suv LICENSE scripts/uninstall.sh
+          tar -czf "out/${{ matrix.archive_name }}" suv LICENSE scripts/uninstall.sh
+          sha256sum "out/${{ matrix.archive_name }}" | awk '{print $1}' > "out/${{ matrix.archive_name }}.sha256"
 
-          # Generate SHA256 checksums
-          sha256sum artifacts/linux/suv-linux${{ matrix.suffix }}-latest.tar.gz | awk '{print $1}' > artifacts/linux/suv-linux${{ matrix.suffix }}-latest.tar.gz.sha256
-
-          # Sign with minisign (secret key from GitHub Secrets, empty password piped)
           echo "$MINISIGN_SECRET_KEY" > /tmp/minisign.key
-          echo '' | minisign -S -s /tmp/minisign.key -m artifacts/linux/suv-linux${{ matrix.suffix }}-latest.tar.gz \
-            -t "suvadu ${{ github.ref_name }} linux${{ matrix.suffix }}" -x artifacts/linux/suv-linux${{ matrix.suffix }}-latest.tar.gz.minisig
+          echo '' | minisign -S \
+            -s /tmp/minisign.key \
+            -m "out/${{ matrix.archive_name }}" \
+            -t "suvadu ${{ github.ref_name }} linux ${{ matrix.arch }}" \
+            -x "out/${{ matrix.archive_name }}.minisig"
           rm -f /tmp/minisign.key
 
-          # Write version.txt for install script version checks
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-${{ matrix.arch }}
+          path: out/*
+          if-no-files-found: error
+
+  publish-linux:
+    name: Publish Linux release
+    runs-on: ubuntu-latest
+    needs: build-linux
+
+    steps:
+      - name: Checkout source repo
+        uses: actions/checkout@v4
+
+      - name: Download x86_64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-x86_64
+          path: artifacts/x86_64
+
+      - name: Download aarch64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-aarch64
+          path: artifacts/aarch64
+
+      - name: Prepare combined artifacts tree
+        run: |
+          set -euo pipefail
+
+          mkdir -p artifacts/linux/archive
+
+          cp artifacts/x86_64/suv-linux-${{ github.ref_name }}.tar.gz artifacts/linux/archive/
+          cp artifacts/x86_64/suv-linux-${{ github.ref_name }}.tar.gz.sha256 artifacts/linux/archive/
+          cp artifacts/x86_64/suv-linux-${{ github.ref_name }}.tar.gz.minisig artifacts/linux/archive/
+
+          cp artifacts/aarch64/suv-linux-aarch64-${{ github.ref_name }}.tar.gz artifacts/linux/archive/
+          cp artifacts/aarch64/suv-linux-aarch64-${{ github.ref_name }}.tar.gz.sha256 artifacts/linux/archive/
+          cp artifacts/aarch64/suv-linux-aarch64-${{ github.ref_name }}.tar.gz.minisig artifacts/linux/archive/
+
+          cp artifacts/linux/archive/suv-linux-${{ github.ref_name }}.tar.gz artifacts/linux/suv-linux-latest.tar.gz
+          cp artifacts/linux/archive/suv-linux-${{ github.ref_name }}.tar.gz.sha256 artifacts/linux/suv-linux-latest.tar.gz.sha256
+          cp artifacts/linux/archive/suv-linux-${{ github.ref_name }}.tar.gz.minisig artifacts/linux/suv-linux-latest.tar.gz.minisig
+
+          cp artifacts/linux/archive/suv-linux-aarch64-${{ github.ref_name }}.tar.gz artifacts/linux/suv-linux-aarch64-latest.tar.gz
+          cp artifacts/linux/archive/suv-linux-aarch64-${{ github.ref_name }}.tar.gz.sha256 artifacts/linux/suv-linux-aarch64-latest.tar.gz.sha256
+          cp artifacts/linux/archive/suv-linux-aarch64-${{ github.ref_name }}.tar.gz.minisig artifacts/linux/suv-linux-aarch64-latest.tar.gz.minisig
+
           echo "${GITHUB_REF_NAME#v}" > artifacts/version.txt
 
-          # Create versioned tarball
-          cp artifacts/linux/suv-linux${{ matrix.suffix }}-latest.tar.gz artifacts/linux/archive/suv-linux${{ matrix.suffix }}-${{ github.ref_name }}.tar.gz
-          cp artifacts/linux/suv-linux${{ matrix.suffix }}-latest.tar.gz.sha256 artifacts/linux/archive/suv-linux${{ matrix.suffix }}-${{ github.ref_name }}.tar.gz.sha256
-          cp artifacts/linux/suv-linux${{ matrix.suffix }}-latest.tar.gz.minisig artifacts/linux/archive/suv-linux${{ matrix.suffix }}-${{ github.ref_name }}.tar.gz.minisig
-
       - name: Upload to Cloudflare R2
-        uses: ryand56/r2-upload-action@b801a390acbdeb034c5e684ff5e1361c06639e7c # v1.4
+        uses: ryand56/r2-upload-action@b801a390acbdeb034c5e684ff5e1361c06639e7c
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
           r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           r2-bucket: ${{ secrets.R2_BUCKET }}
           source-dir: artifacts
-          destination-dir: ./ # Destination prefix in bucket
+          destination-dir: ./
 
-      - name: Purge Cloudflare CDN Cache
+      - name: Purge Cloudflare CDN cache
         run: |
           curl -s -X POST \
             "https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE_ID }}/purge_cache" \
@@ -100,18 +151,76 @@ jobs:
             -H "Content-Type: application/json" \
             -d '{
               "files": [
-                "https://downloads.appachi.tech/linux/suv-linux${{ matrix.suffix }}-latest.tar.gz",
-                "https://downloads.appachi.tech/linux/suv-linux${{ matrix.suffix }}-latest.tar.gz.sha256",
-                "https://downloads.appachi.tech/linux/suv-linux${{ matrix.suffix }}-latest.tar.gz.minisig",
+                "https://downloads.appachi.tech/linux/suv-linux-latest.tar.gz",
+                "https://downloads.appachi.tech/linux/suv-linux-latest.tar.gz.sha256",
+                "https://downloads.appachi.tech/linux/suv-linux-latest.tar.gz.minisig",
+                "https://downloads.appachi.tech/linux/suv-linux-aarch64-latest.tar.gz",
+                "https://downloads.appachi.tech/linux/suv-linux-aarch64-latest.tar.gz.sha256",
+                "https://downloads.appachi.tech/linux/suv-linux-aarch64-latest.tar.gz.minisig",
                 "https://downloads.appachi.tech/version.txt"
               ]
             }'
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@v4
+        with:
+          repository: AppachiTech/homebrew-suvadu
+          token: ${{ secrets.GH_PAT }}
+          path: homebrew-tap
+
+      - name: Update Homebrew tap
+        run: |
+          set -euo pipefail
+
+          TAG="${GITHUB_REF_NAME}"
+          FORMULA_PATH="homebrew-tap/Formula/suvadu.rb"
+
+          X64_TARBALL="suv-linux-${TAG}.tar.gz"
+          ARM_TARBALL="suv-linux-aarch64-${TAG}.tar.gz"
+
+          X64_URL="https://downloads.appachi.tech/linux/archive/${X64_TARBALL}"
+          ARM_URL="https://downloads.appachi.tech/linux/archive/${ARM_TARBALL}"
+
+          X64_SHA="$(awk '{print $1}' "artifacts/linux/archive/${X64_TARBALL}.sha256")"
+          ARM_SHA="$(awk '{print $1}' "artifacts/linux/archive/${ARM_TARBALL}.sha256")"
+
+          sed -i.bak -e '/on_linux do/,/end/{
+            /if Hardware::CPU.arm\?/,/else/{
+              s|url ".*"|url "'"${ARM_URL}"'"|
+              s|sha256 ".*"|sha256 "'"${ARM_SHA}"'"|
+            }
+          }' "$FORMULA_PATH"
+
+          sed -i.bak -e '/on_linux do/,/end/{
+            /else/,/end/{
+              s|url ".*"|url "'"${X64_URL}"'"|
+              s|sha256 ".*"|sha256 "'"${X64_SHA}"'"|
+            }
+          }' "$FORMULA_PATH"
+
+          rm -f "${FORMULA_PATH}.bak"
+
+          cd homebrew-tap
+          git config user.name "Appachi Bot"
+          git config user.email "bot@appachi.tech"
+          git add Formula/suvadu.rb
+
+          if git diff --cached --quiet; then
+            echo "No Homebrew tap changes to commit."
+          else
+            git commit -m "Update suvadu to ${TAG}"
+            git push
+          fi
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: false
           files: |
-            artifacts/linux/archive/suv-linux${{ matrix.suffix }}-${{ github.ref_name }}.tar.gz
-            artifacts/linux/archive/suv-linux${{ matrix.suffix }}-${{ github.ref_name }}.tar.gz.sha256
-            artifacts/linux/archive/suv-linux${{ matrix.suffix }}-${{ github.ref_name }}.tar.gz.minisig
+            artifacts/linux/archive/suv-linux-${{ github.ref_name }}.tar.gz
+            artifacts/linux/archive/suv-linux-${{ github.ref_name }}.tar.gz.sha256
+            artifacts/linux/archive/suv-linux-${{ github.ref_name }}.tar.gz.minisig
+            artifacts/linux/archive/suv-linux-aarch64-${{ github.ref_name }}.tar.gz
+            artifacts/linux/archive/suv-linux-aarch64-${{ github.ref_name }}.tar.gz.sha256
+            artifacts/linux/archive/suv-linux-aarch64-${{ github.ref_name }}.tar.gz.minisig
+

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -189,6 +189,25 @@ jobs:
 
           rm -f "${FORMULA_PATH}.bak"
 
+          # Fail loudly if the sed substitutions did not land — e.g. the formula
+          # layout changed, or homebrew-suvadu#3 (which defines that layout) is
+          # not merged yet. Without this check an unchanged formula would slip
+          # through the "nothing to commit" guard below and users would silently
+          # receive a stale tarball URL / checksum.
+          assert_in_formula() {
+            local label="$1" needle="$2"
+            if ! grep -qF -- "$needle" "$FORMULA_PATH"; then
+              echo "ERROR: ${label} not found in ${FORMULA_PATH} after sed: ${needle}" >&2
+              echo "       Formula layout may have changed or homebrew-suvadu#3 is unmerged;" >&2
+              echo "       refusing to push a stale formula." >&2
+              exit 1
+            fi
+          }
+          assert_in_formula "macos arm64 url"     "$ARM_URL"
+          assert_in_formula "macos arm64 sha256"  "$ARM_SHA"
+          assert_in_formula "macos x86_64 url"    "$X64_URL"
+          assert_in_formula "macos x86_64 sha256" "$X64_SHA"
+
           cd homebrew-tap
           git config user.name "Appachi Bot"
           git config user.email "bot@appachi.tech"

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -3,82 +3,131 @@ name: Release macOS
 on:
   push:
     tags:
-      - 'v*' # Triggers on tags like v0.1.0, v1.0.0
+      - 'v*'
 
 jobs:
-  deploy-mac:
+  build-macos:
+    name: Build macOS (${{ matrix.arch }})
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: aarch64-apple-darwin
             runner: macos-latest
             arch: arm64
             suffix: ""
+            archive_name: suv-macos-${{ github.ref_name }}.tar.gz
           - target: x86_64-apple-darwin
             runner: macos-latest
             arch: x86_64
             suffix: "-x86_64"
+            archive_name: suv-macos-x86_64-${{ github.ref_name }}.tar.gz
+
     runs-on: ${{ matrix.runner }}
+
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
 
-      - name: Run Tests
-        if: matrix.suffix == ''
+      - name: Run tests
+        if: matrix.arch == 'arm64'
         run: cargo test
 
-      - name: Build Binary (Release)
+      - name: Build binary
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Install minisign
         run: brew install minisign
 
-      - name: Prepare Artifacts
+      - name: Prepare release files
         env:
           MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
         run: |
-          # Create directory structure for R2
-          mkdir -p artifacts/macos/archive
+          set -euo pipefail
 
-          # Prepare binary
+          mkdir -p out
+
           cp target/${{ matrix.target }}/release/suv suv
 
-          # Create main tarball (e.g. suv-macos-latest.tar.gz or suv-macos-x86_64-latest.tar.gz)
-          tar -czf artifacts/macos/suv-macos${{ matrix.suffix }}-latest.tar.gz suv LICENSE scripts/uninstall.sh
+          tar -czf "out/${{ matrix.archive_name }}" suv LICENSE scripts/uninstall.sh
+          shasum -a 256 "out/${{ matrix.archive_name }}" | awk '{print $1}' > "out/${{ matrix.archive_name }}.sha256"
 
-          # Generate SHA256 checksums
-          shasum -a 256 artifacts/macos/suv-macos${{ matrix.suffix }}-latest.tar.gz | awk '{print $1}' > artifacts/macos/suv-macos${{ matrix.suffix }}-latest.tar.gz.sha256
-
-          # Sign with minisign (secret key from GitHub Secrets, empty password piped)
           echo "$MINISIGN_SECRET_KEY" > /tmp/minisign.key
-          echo '' | minisign -S -s /tmp/minisign.key -m artifacts/macos/suv-macos${{ matrix.suffix }}-latest.tar.gz \
-            -t "suvadu ${{ github.ref_name }} macOS${{ matrix.suffix }}" -x artifacts/macos/suv-macos${{ matrix.suffix }}-latest.tar.gz.minisig
+          echo '' | minisign -S \
+            -s /tmp/minisign.key \
+            -m "out/${{ matrix.archive_name }}" \
+            -t "suvadu ${{ github.ref_name }} macOS ${{ matrix.arch }}" \
+            -x "out/${{ matrix.archive_name }}.minisig"
           rm -f /tmp/minisign.key
 
-          # Write version.txt for install script version checks
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-${{ matrix.arch }}
+          path: out/*
+          if-no-files-found: error
+
+  publish-macos:
+    name: Publish macOS release
+    runs-on: macos-latest
+    needs: build-macos
+
+    steps:
+      - name: Checkout source repo
+        uses: actions/checkout@v4
+
+      - name: Download arm64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-arm64
+          path: artifacts/arm64
+
+      - name: Download x86_64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-x86_64
+          path: artifacts/x86_64
+
+      - name: Prepare combined artifacts tree
+        run: |
+          set -euo pipefail
+
+          mkdir -p artifacts/macos/archive
+
+          cp artifacts/arm64/suv-macos-${{ github.ref_name }}.tar.gz artifacts/macos/archive/
+          cp artifacts/arm64/suv-macos-${{ github.ref_name }}.tar.gz.sha256 artifacts/macos/archive/
+          cp artifacts/arm64/suv-macos-${{ github.ref_name }}.tar.gz.minisig artifacts/macos/archive/
+
+          cp artifacts/x86_64/suv-macos-x86_64-${{ github.ref_name }}.tar.gz artifacts/macos/archive/
+          cp artifacts/x86_64/suv-macos-x86_64-${{ github.ref_name }}.tar.gz.sha256 artifacts/macos/archive/
+          cp artifacts/x86_64/suv-macos-x86_64-${{ github.ref_name }}.tar.gz.minisig artifacts/macos/archive/
+
+          cp artifacts/macos/archive/suv-macos-${{ github.ref_name }}.tar.gz artifacts/macos/suv-macos-latest.tar.gz
+          cp artifacts/macos/archive/suv-macos-${{ github.ref_name }}.tar.gz.sha256 artifacts/macos/suv-macos-latest.tar.gz.sha256
+          cp artifacts/macos/archive/suv-macos-${{ github.ref_name }}.tar.gz.minisig artifacts/macos/suv-macos-latest.tar.gz.minisig
+
+          cp artifacts/macos/archive/suv-macos-x86_64-${{ github.ref_name }}.tar.gz artifacts/macos/suv-macos-x86_64-latest.tar.gz
+          cp artifacts/macos/archive/suv-macos-x86_64-${{ github.ref_name }}.tar.gz.sha256 artifacts/macos/suv-macos-x86_64-latest.tar.gz.sha256
+          cp artifacts/macos/archive/suv-macos-x86_64-${{ github.ref_name }}.tar.gz.minisig artifacts/macos/suv-macos-x86_64-latest.tar.gz.minisig
+
           echo "${GITHUB_REF_NAME#v}" > artifacts/version.txt
 
-          # Create versioned tarball (e.g. suv-macos-v0.1.0.tar.gz)
-          cp artifacts/macos/suv-macos${{ matrix.suffix }}-latest.tar.gz artifacts/macos/archive/suv-macos${{ matrix.suffix }}-${{ github.ref_name }}.tar.gz
-          cp artifacts/macos/suv-macos${{ matrix.suffix }}-latest.tar.gz.sha256 artifacts/macos/archive/suv-macos${{ matrix.suffix }}-${{ github.ref_name }}.tar.gz.sha256
-          cp artifacts/macos/suv-macos${{ matrix.suffix }}-latest.tar.gz.minisig artifacts/macos/archive/suv-macos${{ matrix.suffix }}-${{ github.ref_name }}.tar.gz.minisig
-
       - name: Upload to Cloudflare R2
-        uses: ryand56/r2-upload-action@b801a390acbdeb034c5e684ff5e1361c06639e7c # v1.4
+        uses: ryand56/r2-upload-action@b801a390acbdeb034c5e684ff5e1361c06639e7c
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
           r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           r2-bucket: ${{ secrets.R2_BUCKET }}
           source-dir: artifacts
-          destination-dir: ./ # Destination prefix in bucket
+          destination-dir: ./
 
-      - name: Purge Cloudflare CDN Cache
+      - name: Purge Cloudflare CDN cache
         run: |
           curl -s -X POST \
             "https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE_ID }}/purge_cache" \
@@ -86,53 +135,76 @@ jobs:
             -H "Content-Type: application/json" \
             -d '{
               "files": [
-                "https://downloads.appachi.tech/macos/suv-macos${{ matrix.suffix }}-latest.tar.gz",
-                "https://downloads.appachi.tech/macos/suv-macos${{ matrix.suffix }}-latest.tar.gz.sha256",
-                "https://downloads.appachi.tech/macos/suv-macos${{ matrix.suffix }}-latest.tar.gz.minisig",
+                "https://downloads.appachi.tech/macos/suv-macos-latest.tar.gz",
+                "https://downloads.appachi.tech/macos/suv-macos-latest.tar.gz.sha256",
+                "https://downloads.appachi.tech/macos/suv-macos-latest.tar.gz.minisig",
+                "https://downloads.appachi.tech/macos/suv-macos-x86_64-latest.tar.gz",
+                "https://downloads.appachi.tech/macos/suv-macos-x86_64-latest.tar.gz.sha256",
+                "https://downloads.appachi.tech/macos/suv-macos-x86_64-latest.tar.gz.minisig",
                 "https://downloads.appachi.tech/version.txt"
               ]
             }'
 
-      - name: Checkout Homebrew Tap
-        if: matrix.suffix == ''
+      - name: Checkout Homebrew tap
         uses: actions/checkout@v4
         with:
           repository: AppachiTech/homebrew-suvadu
           token: ${{ secrets.GH_PAT }}
           path: homebrew-tap
 
-      - name: Update Homebrew Tap
-        if: matrix.suffix == ''
+      - name: Update Homebrew tap
         run: |
-          TAG=${{ github.ref_name }}
-          TARBALL_NAME="suv-macos-${TAG}.tar.gz"
-          TARBALL_PATH="artifacts/macos/archive/${TARBALL_NAME}"
+          set -euo pipefail
 
-          # Calculate SHA256
-          SHASUM=$(shasum -a 256 "$TARBALL_PATH" | awk '{print $1}')
-          echo "SHA256: $SHASUM"
+          TAG="${GITHUB_REF_NAME}"
+          FORMULA_PATH="homebrew-tap/Formula/suvadu.rb"
+
+          ARM_TARBALL="suv-macos-${TAG}.tar.gz"
+          X64_TARBALL="suv-macos-x86_64-${TAG}.tar.gz"
+
+          ARM_URL="https://downloads.appachi.tech/macos/archive/${ARM_TARBALL}"
+          X64_URL="https://downloads.appachi.tech/macos/archive/${X64_TARBALL}"
+
+          ARM_SHA="$(awk '{print $1}' "artifacts/macos/archive/${ARM_TARBALL}.sha256")"
+          X64_SHA="$(awk '{print $1}' "artifacts/macos/archive/${X64_TARBALL}.sha256")"
+
+          sed -i.bak -e '/on_macos do/,/on_linux do/{
+            /if Hardware::CPU.arm\?/,/else/{
+              s|url ".*"|url "'"${ARM_URL}"'"|
+              s|sha256 ".*"|sha256 "'"${ARM_SHA}"'"|
+            }
+          }' "$FORMULA_PATH"
+
+          sed -i.bak -e '/on_macos do/,/on_linux do/{
+            /else/,/end/{
+              s|url ".*"|url "'"${X64_URL}"'"|
+              s|sha256 ".*"|sha256 "'"${X64_SHA}"'"|
+            }
+          }' "$FORMULA_PATH"
+
+          rm -f "${FORMULA_PATH}.bak"
 
           cd homebrew-tap
-          FORMULA_PATH="Formula/suvadu.rb"
-
-          # Update version, URL, and SHA256
-          sed -i '' "s/version \".*\"/version \"${TAG#v}\"/" "$FORMULA_PATH"
-          NEW_URL="https://downloads.appachi.tech/macos/archive/${TARBALL_NAME}"
-          sed -i '' "s|url \".*\"|url \"${NEW_URL}\"|" "$FORMULA_PATH"
-          sed -i '' "s/sha256 \".*\"/sha256 \"${SHASUM}\"/" "$FORMULA_PATH"
-
-          # Commit and push
           git config user.name "Appachi Bot"
           git config user.email "bot@appachi.tech"
-          git add "$FORMULA_PATH"
-          git commit -m "Update suvadu to $TAG"
-          git push
+          git add Formula/suvadu.rb
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+          if git diff --cached --quiet; then
+            echo "No Homebrew tap changes to commit."
+          else
+            git commit -m "Update suvadu to ${TAG}"
+            git push
+          fi
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: ${{ matrix.suffix == '' }}
+          generate_release_notes: true
           files: |
-            artifacts/macos/archive/suv-macos${{ matrix.suffix }}-${{ github.ref_name }}.tar.gz
-            artifacts/macos/archive/suv-macos${{ matrix.suffix }}-${{ github.ref_name }}.tar.gz.sha256
-            artifacts/macos/archive/suv-macos${{ matrix.suffix }}-${{ github.ref_name }}.tar.gz.minisig
+            artifacts/macos/archive/suv-macos-${{ github.ref_name }}.tar.gz
+            artifacts/macos/archive/suv-macos-${{ github.ref_name }}.tar.gz.sha256
+            artifacts/macos/archive/suv-macos-${{ github.ref_name }}.tar.gz.minisig
+            artifacts/macos/archive/suv-macos-x86_64-${{ github.ref_name }}.tar.gz
+            artifacts/macos/archive/suv-macos-x86_64-${{ github.ref_name }}.tar.gz.sha256
+            artifacts/macos/archive/suv-macos-x86_64-${{ github.ref_name }}.tar.gz.minisig
+

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -3,7 +3,7 @@ name: Release macOS
 on:
   push:
     tags:
-      - 'v*'
+      - 'v*' # Triggers on tags like v0.1.0, v1.0.0
 
 jobs:
   build-macos:
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
-      - name: Checkout code
+      - name: Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust
@@ -34,17 +34,17 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Run tests
+      - name: Run Tests
         if: matrix.arch == 'arm64'
         run: cargo test
 
-      - name: Build binary
+      - name: Build Binary (Release)
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Install minisign
         run: brew install minisign
 
-      - name: Prepare release files
+      - name: Prepare Artifacts
         env:
           MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
         run: |
@@ -65,7 +65,7 @@ jobs:
             -x "out/${{ matrix.archive_name }}.minisig"
           rm -f /tmp/minisign.key
 
-      - name: Upload workflow artifact
+      - name: Upload Workflow Artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: macos-${{ matrix.arch }}
@@ -83,22 +83,22 @@ jobs:
       cancel-in-progress: false
 
     steps:
-      - name: Checkout source repo
+      - name: Checkout Source Repo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Download arm64 artifact
+      - name: Download arm64 Artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: macos-arm64
           path: artifacts/arm64
 
-      - name: Download x86_64 artifact
+      - name: Download x86_64 Artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: macos-x86_64
           path: artifacts/x86_64
 
-      - name: Prepare combined artifacts tree
+      - name: Prepare Combined Artifacts Tree
         run: |
           set -euo pipefail
 
@@ -130,9 +130,9 @@ jobs:
           r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           r2-bucket: ${{ secrets.R2_BUCKET }}
           source-dir: artifacts
-          destination-dir: ./
+          destination-dir: ./ # Destination prefix in bucket
 
-      - name: Purge Cloudflare CDN cache
+      - name: Purge Cloudflare CDN Cache
         run: |
           curl -s -X POST \
             "https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE_ID }}/purge_cache" \
@@ -150,14 +150,14 @@ jobs:
               ]
             }'
 
-      - name: Checkout Homebrew tap
+      - name: Checkout Homebrew Tap
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: AppachiTech/homebrew-suvadu
           token: ${{ secrets.GH_PAT }}
           path: homebrew-tap
 
-      - name: Update Homebrew tap
+      - name: Update Homebrew Tap
         run: |
           set -euo pipefail
 
@@ -237,7 +237,7 @@ jobs:
             done
           fi
 
-      - name: Create GitHub release
+      - name: Create GitHub Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           generate_release_notes: true

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -76,6 +76,11 @@ jobs:
     name: Publish macOS release
     runs-on: macos-latest
     needs: build-macos
+    # Serialize against the Linux publish job: both update the same Homebrew
+    # formula in AppachiTech/homebrew-suvadu, so they must not push in parallel.
+    concurrency:
+      group: homebrew-tap-update
+      cancel-in-progress: false
 
     steps:
       - name: Checkout source repo
@@ -192,8 +197,25 @@ jobs:
           if git diff --cached --quiet; then
             echo "No Homebrew tap changes to commit."
           else
-            git commit -m "Update suvadu to ${TAG}"
-            git push
+            git commit -m "Update suvadu (macos) to ${TAG}"
+
+            # The concurrency group serializes us against the Linux workflow,
+            # but rebase-and-retry anyway in case the tap moved under us (e.g. a
+            # manual re-run). The macOS/linux edits touch disjoint blocks of the
+            # formula, so a rebase merges cleanly.
+            BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+            for attempt in 1 2 3 4 5; do
+              if git push origin "HEAD:${BRANCH}"; then
+                echo "Pushed tap update on attempt ${attempt}."
+                break
+              fi
+              if [ "${attempt}" -eq 5 ]; then
+                echo "ERROR: failed to push tap update after ${attempt} attempts." >&2
+                exit 1
+              fi
+              echo "Push rejected (attempt ${attempt}); rebasing on origin/${BRANCH}..."
+              git pull --rebase origin "${BRANCH}"
+            done
           fi
 
       - name: Create GitHub release

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           targets: ${{ matrix.target }}
 
@@ -66,7 +66,7 @@ jobs:
           rm -f /tmp/minisign.key
 
       - name: Upload workflow artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: macos-${{ matrix.arch }}
           path: out/*
@@ -84,16 +84,16 @@ jobs:
 
     steps:
       - name: Checkout source repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download arm64 artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: macos-arm64
           path: artifacts/arm64
 
       - name: Download x86_64 artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: macos-x86_64
           path: artifacts/x86_64
@@ -123,7 +123,7 @@ jobs:
           echo "${GITHUB_REF_NAME#v}" > artifacts/version.txt
 
       - name: Upload to Cloudflare R2
-        uses: ryand56/r2-upload-action@b801a390acbdeb034c5e684ff5e1361c06639e7c
+        uses: ryand56/r2-upload-action@b801a390acbdeb034c5e684ff5e1361c06639e7c # v1.4
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -151,7 +151,7 @@ jobs:
             }'
 
       - name: Checkout Homebrew tap
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: AppachiTech/homebrew-suvadu
           token: ${{ secrets.GH_PAT }}
@@ -238,7 +238,7 @@ jobs:
           fi
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           generate_release_notes: true
           files: |


### PR DESCRIPTION
Dear Maintainers,

these github workflow improvements automatically update the homebrew file in the repo AppachiTech/homebrew-suvadu for MacOS ARM64/x86_64 and Linux ARM64/x86_64 whenever a new release happens. This PR requires the PR AppachiTech/homebrew-suvadu#3 to be merged, so please consider them in tandem.

I could not test the github workflows, but had an AI review them and made sure that the sed replacements work as they should.

Best,
Paul