### PR TITLE
docs: troubleshooting for stale binary path after install-method switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ Verify: `suv status`
 
 ---
 
+## Troubleshooting
+
+**`no such file or directory` pointing at an old path** (e.g. `suv:8: no such file or directory: /opt/homebrew/bin/suv`) — The shell hook records the absolute path of the `suv` binary when your session starts. If you move the binary — switching package managers (e.g. Homebrew → Cargo), running `brew unlink suvadu`, or uninstalling and reinstalling elsewhere — already-open shells keep pointing at the old, now-deleted path. Reload the shell to pick up the new location:
+
+```bash
+exec zsh    # or: exec bash
+```
+
+(or just open a new terminal). Also make sure the new location, such as `~/.cargo/bin`, is on your `PATH`.
+
+More at [suvadu.sh/cli/shell-integration](https://suvadu.sh/cli/shell-integration/).
+
+---
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## What

Adds a README **Troubleshooting** entry for the `no such file or directory` error that appears when the `suv` binary moves but already-open shells still reference the old path.

## Why

The shell hook records the absolute path of the `suv` binary at session start. Switching package managers (e.g. Homebrew → Cargo), running `brew unlink suvadu`, or reinstalling elsewhere leaves open shells pointing at the old, now-deleted path — producing `suv:8: no such file or directory: /opt/homebrew/bin/suv` on every prompt. The fix is to reload the shell (`exec zsh` / `exec bash`).

Companion docs added to the website (suvadu.sh) Shell Integration and Update pages in suvadu-web.

## Scope

README only — docs change, no code.