### PR TITLE
Added opencode to agent detection

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -72,6 +72,9 @@ __suvadu_detect_executor() {
     elif [[ -n "$COPILOT_WORKSPACE" ]]; then
         executor_type="agent"
         executor="copilot"
+    elif [[ -n "$OPENCODE" ]]; then
+        executor_type="agent"
+        executor="opencode"
     elif [[ "$CURSOR_AGENT" == "1" ]]; then
         executor_type="agent"
         executor="cursor"
@@ -1132,6 +1135,7 @@ mod tests {
         // Should still have built-in agents
         assert!(script.contains("CLAUDE_CODE"));
         assert!(script.contains("CURSOR_INJECTION"));
+        assert!(script.contains("OPENCODE"));
         // No custom elif blocks between CI and built-in agents
         let ci_end = script.find("ci-unknown").unwrap();
         let agent_start = script.find("CLAUDE_CODE").unwrap();


### PR DESCRIPTION
This PR adds Opencode to the list of recognized agents. Addresses issue  #27 

I run test command:
```
>> opencode run "Run echo 'test test test'"

> build · deepseek-v4-flash-free

$ echo 'test test test'
test test test
```

Then check if it is properly recorded:
```
>> suv history --executor opencode | grep "test test test"
2026-07-23 15:41:01  ✓        0ms  ~/workspace/suvadu    echo 'test test test'
```